### PR TITLE
Remove 'Entering DMUMPS driver' messages

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -9,7 +9,7 @@ version = v"1.6.0"
 sources = [
     "https://github.com/coin-or-tools/ThirdParty-Mumps/archive/releases/1.6.0.tar.gz" =>
     "3f2bb7d13333e85a29cd2dadc78a38bbf469bc3920c4c0933a90b7d8b8dc798a",
-
+    "./bundled"
 ]
 
 # Bash recipe for building across all platforms
@@ -17,6 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 cd ThirdParty-Mumps-releases-1.6.0/
 ./get.Mumps
+patch -p1 < $WORKSPACE/srcdir/patches/quiet.diff
 update_configure_scripts
 # temporary fix
 for path in ${LD_LIBRARY_PATH//:/ }; do

--- a/bundled/patches/quiet.diff
+++ b/bundled/patches/quiet.diff
@@ -1,0 +1,20 @@
+index af0b62a..55e372e 100644
+--- a/MUMPS/src/dmumps_part1.F
++++ b/MUMPS/src/dmumps_part1.F
+@@ -104,16 +104,6 @@ C       matrix in assembled format (ICNTL(5)=0, and ICNTL(18) $\neq$ 3),
+         MPG     = id%ICNTL(3)
+         PROK    = ((MP.GT.0).AND.(id%ICNTL(4).GE.3))
+         PROKG   = ( MPG .GT. 0 .and. id%MYID .eq. MASTER )
+-        IF (PROKG) THEN
+-           IF (id%ICNTL(5) .NE. 1) THEN
+-              WRITE(MPG,'(A,I4,I12,I15)') 
+-     &             'Entering DMUMPS driver with JOB, N, NZ =', JOB,N,NZ
+-           ELSE
+-              WRITE(MPG,'(A,I4,I12,I15)') 
+-     &             'Entering DMUMPS driver with JOB, N, NELT =', JOB,N
+-     &             ,NELT
+-           ENDIF
+-        ENDIF
+       ELSE
+         MPG = 0
+         PROK = .FALSE.


### PR DESCRIPTION
The library built by this builder is used by SDPA so this changes will prevent this to be printed at every SDPA solve.
See
https://travis-ci.org/JuliaOpt/SDPA.jl/jobs/539691243#L508-L679